### PR TITLE
Introduced cxf client-wide property quarkus.cxf.client.tls-configurat…

### DIFF
--- a/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/deployment/CxfClientProcessor.java
+++ b/extensions/core/deployment/src/main/java/io/quarkiverse/cxf/deployment/CxfClientProcessor.java
@@ -1,43 +1,6 @@
 package io.quarkiverse.cxf.deployment;
 
-import java.io.IOException;
-import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.TreeMap;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.inject.Disposes;
-import jakarta.enterprise.inject.Produces;
-import jakarta.enterprise.inject.spi.InjectionPoint;
-import jakarta.inject.Inject;
-import jakarta.xml.ws.BindingProvider;
-import jakarta.xml.ws.soap.SOAPBinding;
-
-import org.apache.cxf.endpoint.Client;
-import org.apache.cxf.transport.http.HTTPTransportFactory;
-import org.apache.cxf.wsdl11.CatalogWSDLLocator;
-import org.apache.cxf.wsdl11.WSDLManagerImpl;
-import org.jboss.jandex.AnnotationInstance;
-import org.jboss.jandex.AnnotationTarget;
-import org.jboss.jandex.AnnotationValue;
-import org.jboss.jandex.ClassInfo;
-import org.jboss.jandex.DotName;
-import org.jboss.jandex.IndexView;
-import org.jboss.jandex.MethodInfo;
-import org.jboss.jandex.MethodParameterInfo;
-import org.jboss.jandex.Type;
-import org.jboss.logging.Logger;
-
 import io.quarkiverse.cxf.CXFClientData;
-import io.quarkiverse.cxf.CXFClientInfo;
 import io.quarkiverse.cxf.CXFRecorder;
 import io.quarkiverse.cxf.ClientInjectionPoint;
 import io.quarkiverse.cxf.CxfClientProducer;
@@ -45,7 +8,6 @@ import io.quarkiverse.cxf.CxfConfig;
 import io.quarkiverse.cxf.CxfFixedConfig;
 import io.quarkiverse.cxf.CxfFixedConfig.ClientFixedConfig;
 import io.quarkiverse.cxf.HTTPConduitImpl;
-import io.quarkiverse.cxf.HttpClientHTTPConduitFactory;
 import io.quarkiverse.cxf.annotation.CXFClient;
 import io.quarkiverse.cxf.graal.QuarkusCxfFeature;
 import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
@@ -70,6 +32,41 @@ import io.quarkus.gizmo.FieldCreator;
 import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.tls.runtime.CertificateRecorder;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Disposes;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.inject.Inject;
+import jakarta.xml.ws.BindingProvider;
+import jakarta.xml.ws.soap.SOAPBinding;
+import org.apache.cxf.endpoint.Client;
+import org.apache.cxf.transport.http.HTTPTransportFactory;
+import org.apache.cxf.wsdl11.CatalogWSDLLocator;
+import org.apache.cxf.wsdl11.WSDLManagerImpl;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.MethodParameterInfo;
+import org.jboss.jandex.Type;
+import org.jboss.logging.Logger;
+
+import java.io.IOException;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Find WebService implementations and deploy them.
@@ -552,6 +549,14 @@ public class CxfClientProcessor {
     @BuildStep
     ReflectiveClassBuildItem reflectiveClass() {
         return ReflectiveClassBuildItem.builder(HTTPTransportFactory.class).fields().build();
+    }
+
+    /**
+     * Temporary workaround https://github.com/quarkiverse/quarkus-cxf/issues/1680 until Quarkus 3.20 is released
+     */
+    @BuildStep
+    ReflectiveClassBuildItem tempVerifyCertificateConfigInternal() {
+        return ReflectiveClassBuildItem.builder(CertificateRecorder.class).methods().build();
     }
 
     private static class ProxyInfo {

--- a/extensions/core/runtime/src/main/java/io/quarkiverse/cxf/CxfConfig.java
+++ b/extensions/core/runtime/src/main/java/io/quarkiverse/cxf/CxfConfig.java
@@ -1,9 +1,5 @@
 package io.quarkiverse.cxf;
 
-import java.time.Duration;
-import java.util.Map;
-import java.util.Optional;
-
 import io.quarkiverse.cxf.LoggingConfig.GlobalLoggingConfig;
 import io.quarkus.runtime.annotations.ConfigDocIgnore;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
@@ -17,6 +13,10 @@ import io.smallrye.config.WithConverter;
 import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithDefaults;
 import io.smallrye.config.WithName;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
 
 @ConfigMapping(prefix = "quarkus.cxf")
 @ConfigRoot(phase = ConfigPhase.RUN_TIME)
@@ -98,6 +98,13 @@ public interface CxfConfig {
     public Map<String, CxfEndpointConfig> endpoints();
 
     /**
+     * Global client related configurations.
+     *
+     * @asciidoclet
+     */
+    public CxfGlobalClientConfig client();
+
+    /**
      * Configure client proxies.
      *
      * @asciidoclet
@@ -136,6 +143,35 @@ public interface CxfConfig {
 
     default CxfClientConfig getClient(String key) {
         return Optional.ofNullable(clients()).map(m -> m.get(key)).orElse(null);
+    }
+
+    public interface CxfGlobalClientConfig {
+        // The formatter breaks the list with long items
+        // @formatter:off
+        /**
+         * The name of the TLS configuration to use for setting up trust store and keystore for all clients.This setting can be
+         * overridden per client using
+         * `xref:#quarkus-cxf_quarkus-cxf-client-client-name-tls-configuration-name[quarkus.cxf.client."client-name".tls-configuration-name]`
+         *
+         * For each client, if the per-client `.tls-configuration-name` or `.trust-store` or `.key-store` is configured then the
+         * relevant per client configuration will be used.
+         * Otherwise, this configuration will be used.
+         *
+         * By default, if the `javax.net.ssl.trustStore` system property is defined, then its value is honored as a truststore
+         * Otherwise, the paths `$JAVA_HOME/lib/security/jssecacerts` and `$JAVA_HOME/lib/security/cacerts` are checked
+         * and the first existing file is used as a truststore
+         * Otherwise an `IllegalStateException` is thrown.
+         *
+         * The password for opening the truststore is taken from the `javax.net.ssl.trustStorePassword` system property.
+         * If it is not set, the default password `changeit` is used.
+         *
+         * @asciidoclet
+         * @since 3.19.0
+         */
+        // @formatter:on
+        @WithDefault("javax.net.ssl")
+        public String tlsConfigurationName();
+
     }
 
     public interface InternalConfig {

--- a/extensions/core/runtime/src/main/java/io/quarkiverse/cxf/JavaNetSslTlsBucketConfig.java
+++ b/extensions/core/runtime/src/main/java/io/quarkiverse/cxf/JavaNetSslTlsBucketConfig.java
@@ -1,0 +1,171 @@
+package io.quarkiverse.cxf;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.time.Duration;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.tls.runtime.config.JKSTrustStoreConfig;
+import io.quarkus.tls.runtime.config.KeyStoreConfig;
+import io.quarkus.tls.runtime.config.P12TrustStoreConfig;
+import io.quarkus.tls.runtime.config.PemCertsConfig;
+import io.quarkus.tls.runtime.config.TlsBucketConfig;
+import io.quarkus.tls.runtime.config.TrustStoreConfig;
+import io.quarkus.tls.runtime.config.TrustStoreConfig.CertificateExpiryPolicy;
+import io.quarkus.tls.runtime.config.TrustStoreCredentialProviderConfig;
+
+/**
+ * Temporarily hosts the functionality until Quarkus 3.20 is released.
+ * A {@link TlsBucketConfig} mimicking the way how SunJSSE locates the default truststore:
+ * <ol>
+ * <li>If the {@code javax.net.ssl.trustStore} property is defined, then it is honored
+ * <li>If the {@code $JAVA_HOME/lib/security/jssecacerts} is a regular file, then it is used
+ * <li>If the {@code $JAVA_HOME/lib/security/cacerts} is a regular file, then it is used
+ * <li>Otherwise an {@link IllegalStateException} is thrown.
+ * </ol>
+ *
+ * @since 3.18.0
+ */
+class JavaNetSslTlsBucketConfig implements TlsBucketConfig {
+
+    private static final Logger log = Logger.getLogger(JavaNetSslTlsBucketConfig.class);
+
+    JavaNetSslTlsBucketConfig() {
+    }
+
+    @Override
+    public Optional<KeyStoreConfig> keyStore() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<TrustStoreConfig> trustStore() {
+        final Path tsPath = defaultTrustStorePath();
+        final Optional<JKSTrustStoreConfig> jksConfig;
+        final Optional<P12TrustStoreConfig> p12Config;
+        final String tsType = System.getProperty("javax.net.ssl.trustStoreType", KeyStore.getDefaultType())
+                .toLowerCase(Locale.US);
+        final Optional<String> password = Optional
+                .ofNullable(System.getProperty("javax.net.ssl.trustStorePassword", "changeit"));
+        switch (tsType) {
+            case "pkcs12": {
+                p12Config = Optional.of(new JavaNetSslStoreConfig(
+                        tsPath,
+                        password,
+                        Optional.empty(),
+                        null));
+                jksConfig = Optional.empty();
+                break;
+            }
+            case "jks": {
+                p12Config = Optional.empty();
+                jksConfig = Optional.of(new JavaNetSslStoreConfig(
+                        tsPath,
+                        password,
+                        Optional.empty(),
+                        null));
+                break;
+            }
+            default:
+                throw new IllegalArgumentException("Unexpected javax.net.ssl.trustStoreType: " + tsType);
+        }
+        final TrustStoreConfig tsCfg = new JavaNetSslTrustStoreConfig(p12Config, jksConfig, CertificateExpiryPolicy.WARN);
+        return Optional.of(tsCfg);
+    }
+
+    static Path defaultTrustStorePath() {
+        final String rawTsPath = System.getProperty("javax.net.ssl.trustStore");
+        if (rawTsPath != null && !rawTsPath.isEmpty()) {
+            log.debugf("Honoring javax.net.ssl.trustStore property value: %s", rawTsPath);
+            return Path.of(rawTsPath);
+        }
+        final String javaHome = System.getProperty("java.home");
+        if (javaHome == null || javaHome.isEmpty()) {
+            throw new IllegalStateException(
+                    "Could not locate the default Java truststore because the 'java.home' property is not set");
+        }
+        final Path javaHomePath = Path.of(javaHome);
+        if (!Files.isDirectory(javaHomePath)) {
+            throw new IllegalStateException("Could not locate the default Java truststore because the 'java.home' path '"
+                    + javaHome + "' is not a directory");
+        }
+        final Path jssecacerts = javaHomePath.resolve("lib/security/jssecacerts");
+        if (Files.isRegularFile(jssecacerts)) {
+            log.debugf("Using %s as a truststore", jssecacerts);
+            return jssecacerts;
+        }
+        final Path cacerts = javaHomePath.resolve("lib/security/cacerts");
+        if (Files.isRegularFile(cacerts)) {
+            log.debugf("Using %s as a truststore", cacerts);
+            return cacerts;
+        }
+        throw new IllegalStateException(
+                "Could not locate the default Java truststore. Tried javax.net.ssl.trustStore system property, " + jssecacerts
+                        + " and " + cacerts);
+    }
+
+    @Override
+    public Optional<List<String>> cipherSuites() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Set<String> protocols() {
+        return Set.of("TLSv1.3", "TLSv1.2");
+    }
+
+    @Override
+    public Duration handshakeTimeout() {
+        return Duration.parse("10S");
+    }
+
+    @Override
+    public boolean alpn() {
+        return true;
+    }
+
+    @Override
+    public Optional<List<Path>> certificateRevocationList() {
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean trustAll() {
+        return false;
+    }
+
+    @Override
+    public Optional<String> hostnameVerificationAlgorithm() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Duration> reloadPeriod() {
+        return Optional.empty();
+    }
+
+    static record JavaNetSslStoreConfig(Path path, Optional<String> password, Optional<String> alias,
+            Optional<String> provider) implements P12TrustStoreConfig, JKSTrustStoreConfig {
+    }
+
+    static record JavaNetSslTrustStoreConfig(Optional<P12TrustStoreConfig> p12, Optional<JKSTrustStoreConfig> jks,
+            CertificateExpiryPolicy certificateExpirationPolicy) implements TrustStoreConfig {
+
+        @Override
+        public Optional<PemCertsConfig> pem() {
+            return Optional.empty();
+        }
+
+        @Override
+        public TrustStoreCredentialProviderConfig credentialsProvider() {
+            return null;
+        }
+
+    }
+}


### PR DESCRIPTION
…ion-name

The property points to the default java keystore and truststore by default Temporary workarounds are introduced until the java.net.ssl reserved TLS configuration is introduced with Quarkus 3.20